### PR TITLE
Fix for posts hiding the string Sponsored via ShadowRoot (FF only)

### DIFF
--- a/launcher.js
+++ b/launcher.js
@@ -110,6 +110,15 @@ const is_garbage = n => {
         }
     }
 
+	if (n.tagName == "use" && n.openOrClosedShadowRoot)  // only supported in Firefox
+	{
+		let sr = n.openOrClosedShadowRoot
+		if (sr.children.length > 0)
+		{
+			if (is_garbage(sr.children[0])) return true;
+		}
+	}
+
 
     for (const sub_node of n.children) {
         if (is_garbage(sub_node)) {


### PR DESCRIPTION
Uses Element.openOrClosedShadowRoot, which is only supported by Firefox.
![shadowroot](https://user-images.githubusercontent.com/89856263/194703979-9ba058c9-0bab-4906-9ae5-824aee0504f6.png)
